### PR TITLE
Add simple NLP training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,10 @@ As we advance toward an age where the boundaries between technology and magic be
 
 The spell of the story, cast with technological precision and ethical wisdom, remains humanity's most powerful tool for consciousness transformation and collective meaning-making. NARRATIS merely provides the engineering principles for making that magic more intentional, more powerful, and more beneficial for all.
 
+## XI. TRAINING DATA FOR MATHEMAGIC
+
+To showcase a practical extension of the framework, this repository now includes a small dataset and training script in the `ml` directory. The dataset pairs natural language prompts with short Python code snippets. Running `python ml/train_mathemagic.py` builds a lightweight nearest‑neighbor model that retrieves an appropriate snippet for a new prompt. The resulting model is saved to a `models/` folder which is ignored by git.
+
 ---
 
 *"From spinning disc to solid state, I call upon the words of fate. With neologisms bright and new, Transform this drive, make it true. Flash and speed, no more to wait, Access data at lightning rate."*

--- a/ml/train_mathemagic.py
+++ b/ml/train_mathemagic.py
@@ -1,0 +1,39 @@
+import json
+import os
+import joblib
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.neighbors import KNeighborsClassifier
+
+
+def load_data(path: str):
+    """Load training examples from JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    prompts = [d["prompt"] for d in data]
+    codes = [d["code"] for d in data]
+    return prompts, codes
+
+
+def train_model(prompts, codes):
+    """Train a simple nearest neighbor model."""
+    vectorizer = TfidfVectorizer()
+    X = vectorizer.fit_transform(prompts)
+    # Each unique code snippet is considered a label
+    y = list(range(len(codes)))
+    clf = KNeighborsClassifier(n_neighbors=1)
+    clf.fit(X, y)
+    return vectorizer, clf, codes
+
+
+def save_model(vectorizer, clf, codes, out_dir="models"):
+    os.makedirs(out_dir, exist_ok=True)
+    model_path = os.path.join(out_dir, "mathemagic_model.pkl")
+    joblib.dump({"vectorizer": vectorizer, "classifier": clf, "codes": codes}, model_path)
+    return model_path
+
+
+if __name__ == "__main__":
+    prompts, codes = load_data(os.path.join("ml", "training_data.json"))
+    vect, clf, codes = train_model(prompts, codes)
+    path = save_model(vect, clf, codes)
+    print(f"Model saved to {path}")

--- a/ml/training_data.json
+++ b/ml/training_data.json
@@ -1,0 +1,7 @@
+[
+  {"prompt": "create a list of numbers from 1 to 5", "code": "numbers = list(range(1, 6))"},
+  {"prompt": "compute the factorial of n", "code": "def factorial(n):\n    return 1 if n == 0 else n * factorial(n-1)"},
+  {"prompt": "check if a number is prime", "code": "def is_prime(n):\n    if n < 2: return False\n    for i in range(2, int(n ** 0.5)+1):\n        if n % i == 0: return False\n    return True"},
+  {"prompt": "sort a list", "code": "sorted_list = sorted(my_list)"},
+  {"prompt": "print hello world", "code": "print('Hello, world!')"}
+]

--- a/ml/use_model.py
+++ b/ml/use_model.py
@@ -1,0 +1,24 @@
+import sys
+import joblib
+from sklearn.metrics.pairwise import cosine_similarity
+
+MODEL_PATH = 'models/mathemagic_model.pkl'
+
+def load_model(path=MODEL_PATH):
+    return joblib.load(path)
+
+
+def query(prompt: str):
+    model = load_model()
+    vect = model['vectorizer'].transform([prompt])
+    pred = model['classifier'].predict(vect)[0]
+    code = model['codes'][pred]
+    return code
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: python ml/use_model.py "your prompt"')
+        sys.exit(1)
+    prompt = ' '.join(sys.argv[1:])
+    print(query(prompt))


### PR DESCRIPTION
## Summary
- add dataset of prompts and Python snippets
- provide training script using scikit-learn
- include helper script to query the trained model
- update README with notes about the new training data

## Testing
- `python3 -m py_compile ml/train_mathemagic.py ml/use_model.py`
- `python3 ml/train_mathemagic.py`
- `python3 ml/use_model.py "sort a list"`


------
https://chatgpt.com/codex/tasks/task_b_68842b9b56e88326ba95fbdd4a65f3ae