### PR TITLE
Add sample NLP training data and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,3 +559,24 @@ The spell of the story, cast with technological precision and ethical wisdom, re
 *"From spinning disc to solid state, I call upon the words of fate. With neologisms bright and new, Transform this drive, make it true. Flash and speed, no more to wait, Access data at lightning rate."*
 
 The incantation is complete. The framework stands ready for implementation.
+## XI. AI NLP TRAINING MODULE
+
+The repository now includes a small dataset and example scripts for experimenting with narrative classification and mathemagic routines.
+
+### 11.1 Sample Dataset
+
+The file `training/data/narrative_samples.csv` contains short narrative snippets labeled by theme. It can be used to train simple text classifiers or language models.
+
+### 11.2 Training Example
+
+Run `python training/train_nlp.py` to train a basic classifier using scikit-learn. The script prints evaluation metrics for the sample data.
+
+### 11.3 Mathemagic Demo
+
+The script `training/mathemagic.py` demonstrates a playful numeric ritual. Provide a number and it will reduce it to its digital essence while showing each step:
+
+```
+python training/mathemagic.py 9876
+```
+
+These additions offer a starting point for further AI learning experiments within the NARRATIS framework.

--- a/training/data/narrative_samples.csv
+++ b/training/data/narrative_samples.csv
@@ -1,0 +1,10 @@
+text,label
+"The hero solved the puzzle with cunning and bravery",adventure
+"Mysterious lights flickered above the ancient ruins",mystery
+"Quantum circuits danced as the AI composed a new symphony",sci-fi
+"Eldritch runes wove spells into the code itself",fantasy
+"A single line of code summoned perfect fractals from numbers",mathemagic
+"The algorithm whispered secrets of forgotten civilizations",mystery
+"Spaceships soared across the binary star system",sci-fi
+"A cunning rogue deciphered the ancient programming language",adventure
+"Numbers rearranged themselves, revealing hidden messages",mathemagic

--- a/training/mathemagic.py
+++ b/training/mathemagic.py
@@ -1,0 +1,20 @@
+def digit_sum_magic(number: int) -> dict:
+    """Return steps reducing number to a single digit via digit sums."""
+    original = number
+    steps = []
+    while number >= 10:
+        digits = [int(d) for d in str(number)]
+        s = sum(digits)
+        steps.append(" + ".join(str(d) for d in digits) + f" = {s}")
+        number = s
+    return {"original": original, "steps": steps, "result": number}
+
+
+if __name__ == '__main__':
+    import sys
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 12345
+    info = digit_sum_magic(n)
+    print(f"Magic reduction of {info['original']}")
+    for step in info['steps']:
+        print(step)
+    print(f"Result: {info['result']}")

--- a/training/train_nlp.py
+++ b/training/train_nlp.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.model_selection import train_test_split
+from sklearn.naive_bayes import MultinomialNB
+from sklearn.pipeline import make_pipeline
+from sklearn.metrics import classification_report
+
+
+def main():
+    data = pd.read_csv('training/data/narrative_samples.csv')
+    X_train, X_test, y_train, y_test = train_test_split(
+        data['text'], data['label'], test_size=0.2, random_state=42
+    )
+    model = make_pipeline(TfidfVectorizer(), MultinomialNB())
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    print(classification_report(y_test, preds))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add example narrative dataset
- include a simple scikit-learn text classifier
- provide a mathemagic number routine
- document the new training module in README

## Testing
- `python training/train_nlp.py`
- `python training/mathemagic.py 9876`


------
https://chatgpt.com/codex/tasks/task_b_68842b9b56e88326ba95fbdd4a65f3ae