### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  push:
+    branches: [ main, work ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run build script
+        run: |
+          bash scripts/build.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Open this file in a browser or deploy using `./codex_theta_os.sh` to launch the 
    ```
 2. Open `http://localhost:8080/` in a browser to access the UI.
 
+## Continuous Integration
+
+This repository includes a basic GitHub Actions workflow that verifies the
+project builds correctly. The workflow runs on every push and pull request and
+performs a simple Python syntax check while ensuring the web frontend exists.
+
+To view the workflow configuration, see
+`.github/workflows/build.yml`.
+
 ## I. FOUNDATIONAL ARCHITECTURE
 
 ### 1.1 Core Philosophical Substrate

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Basic build check for NARRATIS
+
+# Ensure Python source compiles
+python -m py_compile echodaemon.py
+
+# Verify frontend files exist
+if [ ! -f frontend/static/index.html ]; then
+    echo "frontend missing" >&2
+    exit 1
+fi
+
+echo "Build completed successfully."


### PR DESCRIPTION
## Summary
- add a simple GitHub Actions workflow to check build
- add a minimal build script for CI
- document CI workflow in README

## Testing
- `bash scripts/build.sh`

------
https://chatgpt.com/codex/tasks/task_b_6889c3c473d08326af2f084f1fd7e0d9