### PR TITLE
Ensure systemd directory exists

### DIFF
--- a/codex_theta_os.sh
+++ b/codex_theta_os.sh
@@ -104,6 +104,7 @@ setup_directories() {
         frontend/templates \
         config/nginx \
         config/supervisor \
+        config/systemd \
         config/docker \
         logs \
         scripts \
@@ -344,6 +345,9 @@ EOF
 # ------- Create systemd service file for full system -------
 create_systemd_services() {
     log_step "Creating systemd service files..."
+
+    # Ensure directory exists
+    mkdir -p config/systemd
 
     cat > config/systemd/codex-theta-os.service << EOF
 [Unit]


### PR DESCRIPTION
## Summary
- ensure `config/systemd` directory exists when deploying
- keep directory in git via `.gitkeep`

## Testing
- `pytest -q`
- `bash -n codex_theta_os.sh`


------
https://chatgpt.com/codex/tasks/task_b_6889cc995d8483269fac073806d3ab56