### PR TITLE
Add frontend CI workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,26 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: |
+          if [ -f package.json ]; then
+            yarn install --frozen-lockfile
+          fi
+      - name: Run tests
+        run: |
+          if [ -f package.json ]; then
+            yarn test --ci --runInBand
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for frontend tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889cc995d8483269fac073806d3ab56