### PR TITLE
Fix systemd directory creation

### DIFF
--- a/codex_theta_os.sh
+++ b/codex_theta_os.sh
@@ -105,6 +105,7 @@ setup_directories() {
         config/nginx \
         config/supervisor \
         config/docker \
+        config/systemd \
         logs \
         scripts \
         data/models \


### PR DESCRIPTION
## Summary
- ensure `codex_theta_os.sh` creates `config/systemd`

## Testing
- `make -C kernel/c-daemon`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889cc995d8483269fac073806d3ab56