### PR TITLE
Fix CI to fail on pytest errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
           make -C kernel/c-daemon
       - name: Run tests
         run: |
-          pytest -q || true
+          pytest -q
 


### PR DESCRIPTION
## Summary
- update `ci.yml` so pytest errors will fail the workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889d069a5f08326959b7f2b879dcf96