### PR TITLE
Fix log path in echodaemon

### DIFF
--- a/echodaemon.py
+++ b/echodaemon.py
@@ -687,7 +687,7 @@ async def health_check():
 
 def setup_logging():
     """Configure logging for the EchoDaemon"""
-    log_dir = Path("../logs")
+    log_dir = Path(__file__).parent / "logs"
     log_dir.mkdir(exist_ok=True)
     
     logging.basicConfig(


### PR DESCRIPTION
## Summary
- ensure `setup_logging` creates logs relative to echodaemon.py file

## Testing
- `python -m py_compile echodaemon.py`
- `bash -n codex_theta_os_bootstrap.sh`
- `bash -n codex_theta_os.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889d06b1fd08326a1c6950a36f218e6