### PR TITLE
Add simple FastAPI tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 websockets==12.0
 starlette==0.27.0
+httpx==0.24.1
 
 # LLM Integration - The Consciousness Core
 llama-cpp-python==0.2.11

--- a/tests/test_echodaemon_api.py
+++ b/tests/test_echodaemon_api.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure the project root is in the Python path so `echodaemon` can be imported
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR))
+
+import echodaemon
+
+@pytest.fixture
+def client():
+    with TestClient(echodaemon.app) as c:
+        yield c
+
+def test_health_endpoint(client):
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['status'] == 'alive'
+    assert 'timestamp' in data
+
+def test_hardware_endpoint(client):
+    resp = client.get('/api/hardware')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'hardware' in data
+    assert isinstance(data['hardware'], list)
+    assert len(data['hardware']) > 0
+
+def test_status_endpoint(client):
+    resp = client.get('/api/status')
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ['system_metrics', 'hardware', 'kernel_connected', 'active_connections', 'loaded_drivers']:
+        assert key in data


### PR DESCRIPTION
## Summary
- add TestClient tests for health, hardware, and status endpoints
- ensure `echodaemon` can be imported in tests by adjusting `sys.path`
- pin compatible `httpx` version in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889d06cbaec8326a051465777a246e5