### PR TITLE
Fix duplicate systemd directory

### DIFF
--- a/codex_theta_os.sh
+++ b/codex_theta_os.sh
@@ -106,7 +106,6 @@ setup_directories() {
         config/supervisor \
         config/systemd \
         config/docker \
-        config/systemd \
         logs \
         scripts \
         data/models \


### PR DESCRIPTION
## Summary
- avoid creating `config/systemd` twice

## Testing
- `shellcheck codex_theta_os.sh`

------
https://chatgpt.com/codex/tasks/task_b_6889d06d4fac8326bb2551ef53af3849