### PR TITLE
Add local run script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,21 @@ Open this file in a browser or deploy using `./codex_theta_os.sh` to launch the 
 
 ## Running the FluxShell Interface
 
-1. Start the EchoDaemon server:
+1. Run the provided helper script to install dependencies, build the
+   C daemon and launch the server:
    ```bash
-   python3 echodaemon.py
+   ./scripts/run_local.sh
    ```
+   The script creates a `venv` directory if needed and then starts
+   `echodaemon.py`.
 2. Open `http://localhost:8080/` in a browser to access the UI.
+
+If you prefer a manual setup, run:
+```bash
+pip install -r requirements.txt
+make -C kernel/c-daemon
+python3 echodaemon.py
+```
 
 ## Continuous Integration
 

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Simple setup and run script for NARRATIS
+
+set -e
+
+echo "== NARRATIS Local Run =="
+
+REQUIRED=(python3 pip make gcc)
+for cmd in "${REQUIRED[@]}"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: '$cmd' is required but not installed." >&2
+        exit 1
+    fi
+done
+
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+source venv/bin/activate
+
+pip install -r requirements.txt
+
+make -C kernel/c-daemon
+
+python3 echodaemon.py


### PR DESCRIPTION
## Summary
- add helper script `run_local.sh` for local setup and server start
- document the script and manual setup steps in the README

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6889d2e25ee883268255b40fb62b6b50